### PR TITLE
Fix "Friends" font size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Only for 42's students (www.42.fr), this app is available for all the campus :)
+Only for 42's students (www.42.fr), this app is available for all the campus 🙂
 
 The app is an unofficial Intra 42 client for Android platforms. It's built in JAVA and use official Android SDK.
 
@@ -18,9 +18,9 @@ All feature requests and contributions are welcome!
 
 Useful tools :
 
-> [pdf viewer](https://play.google.com/store/apps/details?id=com.google.android.apps.pdfviewer)
+> [PDF viewer](https://play.google.com/store/apps/details?id=com.google.android.apps.pdfviewer)
 
-> [vlc](https://play.google.com/store/apps/details?id=org.videolan.vlc) for playing e-learning videos.
+> [mpv](https://play.google.com/store/apps/details?id=is.xyz.mpv) for playing e-learning videos.
 
 ## Contribute
 
@@ -31,7 +31,7 @@ You can Contribute to this project by fixing bugs or add missing features.
 Sources : [https://github.com/pvarry/intra42](https://github.com/pvarry/intra42)
 
 To run the app locally you have to :
-- Use Android Studio as IDE.
+- Use Android Studio or IntelliJ IDEA as IDE.
 - Create a application on https://profile.intra.42.fr/oauth/applications
 - Duplicate file on `app/src/debug/java/com/paulvarry/intra42/Credential.java.sample` and fill up with yours credentials.
 
@@ -41,16 +41,6 @@ If you find grammatical mistakes or if you want to translate this app, you can d
 
 ## Screenshot
 
-![home](https://lh3.googleusercontent.com/kVno0ZG2ZQHiG3NXgKsN6pZ7Bx2L18wT54_OCfLJejKYPecyllImXpNQ0KWXRXMFJpE=h310-rw)
-
-![Galaxy](https://lh3.googleusercontent.com/8sl1WUfwK0buyA1BN1uxH0OmhJOfByZfXtJ_u1sVFBPjYPeCQgqin0DnrnNhNwfkW3ot=h310-rw)
-
-![Cluster Map](https://lh3.googleusercontent.com/o5xlA1lXr1qoYWC81RUAg_e4jaWpFg9LoU5kStmR9PuXatqKnUvY8QJ3a2L4M41RKtxd=h310-rw)
-
-![Event](https://lh3.googleusercontent.com/EvbKktad0gKoUU4KBIo4x9eglSHSLlSIfOMgFbIZfIE3Pp6N2ZkguYLYM27nFZOwfg=h310-rw)
-
-![Projects](https://lh3.googleusercontent.com/WWOLxkqUmtg51B5DC0UlJzj1jD-9ju1bDTPcuLd88YW-wFcuHlUDrRcloiOIKpQURZk=h310-rw)
-
-![Projects](https://lh3.googleusercontent.com/9vEGqxY4duq8rK4VeDFgB8rU6JC_8E3kzX1Cl0-jrc3amrPoqFjHwZLTLKpSRdShXkXT=h310-rw)
+![Home](https://beeimg.com/images/m00808116602.jpg)
 
 Disclaimer : This code is in no way affiliated with, authorised, maintained, sponsored or endorsed by 42. This is an independent and unofficial Android app.

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -291,7 +291,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/title_activity_friends"
-                        android:textColor="?attr/colorOnBackground" />
+                        android:textColor="?attr/colorOnBackground"
+                        android:textAppearance="?attr/textAppearanceListItem" />
                 </LinearLayout>
 
                 <LinearLayout


### PR DESCRIPTION
The line that sets the text appearance was missing for the Friends item of the homepage. This caused the font to be smaller than the other buttons.