### PR TITLE
Use usual_full_name instead of displayname (API)

### DIFF
--- a/app/src/main/java/com/paulvarry/intra42/api/model/Users.java
+++ b/app/src/main/java/com/paulvarry/intra42/api/model/Users.java
@@ -22,7 +22,7 @@ public class Users extends UsersLTE {
     private final static String API_LOGIN = "login";
     private final static String API_URL = "url";
     private final static String API_PHONE = "phone";
-    private final static String API_NAME = "displayname";
+    private final static String API_NAME = "usual_full_name";
     private final static String API_IMAGE_URL = "image_url";
     private final static String API_STAFF = "staff?";
     private final static String API_CORRECTION_POINT = "correction_point";


### PR DESCRIPTION
The API just got a new feature: the Usual Name of users is now returned from `/v2/users/` endpoint, so this PR makes use of it.
This is better for people who changed their name because it avoids showing their old/hidden name and acts the same as the intra.